### PR TITLE
Closes #3 로그인/로그아웃 (JWT)

### DIFF
--- a/src/main/java/com/zerobase/minesweeper/controller/AuthController.java
+++ b/src/main/java/com/zerobase/minesweeper/controller/AuthController.java
@@ -1,0 +1,38 @@
+package com.zerobase.minesweeper.controller;
+
+import com.zerobase.minesweeper.dto.LoginRequest;
+import com.zerobase.minesweeper.dto.TokenDto;
+import com.zerobase.minesweeper.dto.TokensRequest;
+import com.zerobase.minesweeper.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+@RestController
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenDto> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request.getEmail(), request.getPassword()));
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenDto> reissue(@Valid @RequestBody TokensRequest request) {
+        return ResponseEntity.ok(authService.reissue(request));
+    }
+
+    /* db에서 refresh token 삭제 후 프론트에서도 토큰 삭제
+    * */
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@Valid @RequestBody TokensRequest request) {
+        return ResponseEntity.ok(authService.logout(request));
+    }
+}

--- a/src/main/java/com/zerobase/minesweeper/dto/LoginRequest.java
+++ b/src/main/java/com/zerobase/minesweeper/dto/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.zerobase.minesweeper.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+public class LoginRequest {
+    @NotBlank
+    private String email;
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/zerobase/minesweeper/dto/TokenDto.java
+++ b/src/main/java/com/zerobase/minesweeper/dto/TokenDto.java
@@ -1,0 +1,11 @@
+package com.zerobase.minesweeper.dto;
+
+import lombok.Data;
+
+@Data
+public class TokenDto {
+    private final String bearerType;
+    private final String accessToken;
+    private final String refreshToken;
+    private final Long gamerId;
+}

--- a/src/main/java/com/zerobase/minesweeper/dto/TokensRequest.java
+++ b/src/main/java/com/zerobase/minesweeper/dto/TokensRequest.java
@@ -1,0 +1,13 @@
+package com.zerobase.minesweeper.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+public class TokensRequest {
+    @NotBlank
+    private String accessToken;
+    @NotBlank
+    private String refreshToken;
+}

--- a/src/main/java/com/zerobase/minesweeper/entity/RefreshToken.java
+++ b/src/main/java/com/zerobase/minesweeper/entity/RefreshToken.java
@@ -1,0 +1,25 @@
+package com.zerobase.minesweeper.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class RefreshToken {
+
+    @Id
+    private Long gamerId; //gamerId 외래키
+
+    private String token; //refresh token
+
+    public void updateToken(String token) {
+        this.token = token;
+    }
+
+}

--- a/src/main/java/com/zerobase/minesweeper/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/zerobase/minesweeper/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.zerobase.minesweeper.repository;
+
+import com.zerobase.minesweeper.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByGamerId(Long gamerId);
+}

--- a/src/main/java/com/zerobase/minesweeper/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/zerobase/minesweeper/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,22 @@
+package com.zerobase.minesweeper.security;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    /*
+    *   필요한 권한(role)이 없이 접근하려 할때 403반환
+    * */
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        System.out.println("JwtAccessDeniedHandler.handle -> "+accessDeniedException.getMessage());
+
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, accessDeniedException.getMessage());
+    }
+}

--- a/src/main/java/com/zerobase/minesweeper/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/zerobase/minesweeper/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package com.zerobase.minesweeper.security;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    /*  토큰 값이 유효하지 않을 때 401반환
+    * */
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        System.out.println("JwtAuthenticationEntryPoint.commence -> "+authException.getMessage());
+
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/zerobase/minesweeper/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zerobase/minesweeper/security/JwtAuthenticationFilter.java
@@ -1,0 +1,50 @@
+package com.zerobase.minesweeper.security;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String TOKEN_HEADER = "Authorization";
+    private static final String TOKEN_PREFIX = "Bearer ";
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && tokenProvider.validateToken(token)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            log.info("security context 에 gamer id:{} 인증 정보 저장", authentication.getName());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String token = request.getHeader(TOKEN_HEADER);
+
+        if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+            return token.substring(TOKEN_PREFIX.length());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/zerobase/minesweeper/security/SecurityConfig.java
+++ b/src/main/java/com/zerobase/minesweeper/security/SecurityConfig.java
@@ -5,8 +5,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -14,6 +20,10 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 @Configuration
 public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAccessDeniedHandler accessDeniedHandler;
+    private final JwtAuthenticationEntryPoint authenticationEntryPoint;
+
     private static final String[] PERMITTED = {
         "/h2-console/**",
         "/gamer/**",
@@ -26,5 +36,50 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring().antMatchers(PERMITTED);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .httpBasic().disable()
+                .csrf().disable()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                /*  rest 관련 설정
+                 * */
+
+                .headers()
+                .frameOptions()
+                .sameOrigin()
+                .and()
+                /*  h2-console 설정
+                 * */
+
+                .exceptionHandling()
+                .authenticationEntryPoint(authenticationEntryPoint)
+                .accessDeniedHandler(accessDeniedHandler)
+                .and()
+                /*  custom handler 등록
+                 * */
+
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .authorizeRequests()
+                .antMatchers("/auth/**")
+                .permitAll()
+                /*  로그인 인증 필요없는 url 설정
+                 * */
+
+                .anyRequest()
+                .authenticated();
+        /*  이외 모두 인증필요
+         * */
+
+        return http.build();
     }
 }

--- a/src/main/java/com/zerobase/minesweeper/security/TokenProvider.java
+++ b/src/main/java/com/zerobase/minesweeper/security/TokenProvider.java
@@ -1,0 +1,102 @@
+package com.zerobase.minesweeper.security;
+
+import com.zerobase.minesweeper.dto.TokenDto;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+
+import javax.crypto.SecretKey;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class TokenProvider {
+    private static final SecretKey SECRET_KEY = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+    private static final String BEARER_TYPE = "Bearer";
+    private static final String KEY_ROLES = "roles";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // 30M
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24; // 1D
+
+    public TokenDto generateToken(Authentication authentication) {
+        Claims claims = Jwts.claims().setSubject(authentication.getName());// claim 데이터 추후 암호화 필요
+        claims.put(KEY_ROLES, authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.joining(" ")));
+
+        Date now = new Date();
+
+        String accessToken = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_TIME))
+                .signWith(SECRET_KEY)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(SECRET_KEY)
+                .compact();
+
+        return new TokenDto(BEARER_TYPE, accessToken, refreshToken, Long.parseLong(authentication.getName()));
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+
+        if (ObjectUtils.isEmpty(claims.get(KEY_ROLES))) {
+            throw new RuntimeException("토큰에 권한 정보가 없습니다.");
+        }
+
+        List<SimpleGrantedAuthority> authentication = Arrays.stream(claims.get(KEY_ROLES).toString().split(" "))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        User user = new User(claims.getSubject(), "", authentication);
+
+        return new UsernamePasswordAuthenticationToken(user, "", user.getAuthorities());
+    }
+
+    public Long getGamerId(String token) {
+        return Long.valueOf(parseClaims(token).getSubject());
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            return parseClaims(token)
+                    .getExpiration().after(new Date());
+        } catch (Exception e) {
+            log.error("token {} error : {}", token, e.getMessage());
+
+            return false;
+        }
+
+    }
+
+    public Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(SECRET_KEY)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+}

--- a/src/main/java/com/zerobase/minesweeper/service/AuthService.java
+++ b/src/main/java/com/zerobase/minesweeper/service/AuthService.java
@@ -1,0 +1,96 @@
+package com.zerobase.minesweeper.service;
+
+import com.zerobase.minesweeper.dto.TokenDto;
+import com.zerobase.minesweeper.dto.TokensRequest;
+import com.zerobase.minesweeper.entity.Gamer;
+import com.zerobase.minesweeper.entity.RefreshToken;
+import com.zerobase.minesweeper.repository.GamerRepository;
+import com.zerobase.minesweeper.repository.RefreshTokenRepository;
+import com.zerobase.minesweeper.security.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AuthService implements UserDetailsService {
+    private final GamerRepository gamerRepository;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Gamer gamer = gamerRepository.findByMail(username)
+                .orElseThrow(() -> new RuntimeException("읎는 아이디 입네다."));
+
+        if (!gamer.isVerified()) {
+            throw new RuntimeException("이메일 인증이 되지 않은 사용자입니다.");
+        }
+
+        return new User(gamer.getId().toString(), gamer.getPswd(),
+                List.of(new SimpleGrantedAuthority(gamer.getRole().toString())));
+    }
+
+    /*
+     *   db에서 멤버 확인
+     *   토큰발급
+     * */
+    public TokenDto login(String email, String password) {
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email, password);
+
+        Authentication authentication = authenticationManagerBuilder.getObject()
+                                        .authenticate(authenticationToken);// authenticate 호출 시 -> loadUserByUsername 실행
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        TokenDto tokenDto = tokenProvider.generateToken(authentication);
+
+        refreshTokenRepository.save(new RefreshToken(Long.parseLong(authentication.getName()), tokenDto.getRefreshToken()));
+        return tokenDto;
+    }
+
+    @Transactional
+    public TokenDto reissue(TokensRequest request) {
+        if (!tokenProvider.validateToken(request.getRefreshToken())) {
+            throw new RuntimeException("refresh token이 만료되었습니다. 재로그인이 필요합니다.");
+        }
+
+        Authentication authentication = tokenProvider.getAuthentication(request.getAccessToken());
+
+        RefreshToken refreshToken = refreshTokenRepository.findByGamerId(Long.valueOf(authentication.getName()))
+                .orElseThrow(() -> new RuntimeException("로그아웃된 사용자입니다."));
+
+        if (!refreshToken.getToken().equals(request.getRefreshToken())) {
+            throw new RuntimeException("토큰의 유저 정보가 일치하지 않습니다.");
+        }
+
+        TokenDto tokenDto = tokenProvider.generateToken(authentication);
+
+        refreshToken.updateToken(tokenDto.getRefreshToken()); // update refresh token in db
+
+        return tokenDto;
+    }
+
+    public boolean logout(TokensRequest request) {
+        Authentication authentication = tokenProvider.getAuthentication(request.getAccessToken());
+
+        RefreshToken refreshToken = refreshTokenRepository.findByGamerId(Long.valueOf(authentication.getName()))
+                .orElseThrow(() -> new RuntimeException("저장된 토큰 값을 찾을 수 없습니다."));
+
+        refreshTokenRepository.delete(refreshToken);
+        return true;
+    }
+}


### PR DESCRIPTION
## security 설정 및 jwt 로그인, 인증 api

- 로그인 api 개발 - 로그인 시 jwt access token 및 refresh token 발행
- jwt filter : 인증이 필요한 요청 시 http header token 유무 확인 및 검증 filter 구현
- token reissue : access token 만료 시 -> RefreshToken check 후 재발급, invalid라면 -> 재로그인 요청
- filter handler : 토큰 유효하지않음 401 에러 반환, 권한(role)없음 -> 403에러 반환 로그아웃 기능 -> db에 저장된 token 삭제
- security configuration 등록